### PR TITLE
changed grpcio version for Apple Silicon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ include = ["esdbclient/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-grpcio = "~1.44.0"
-protobuf = "~3.20.0"
+grpcio = "^1.48.0"
+protobuf = "^3.20.0"
 typing_extensions = "*"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
As mentioned in https://github.com/grpc/grpc/issues/28387#issuecomment-1159164226, `grpcio = "~1.44.0"` is not working for MacOS Applie Silicon.
[v1.47.0](https://github.com/grpc/grpc/releases/tag/v1.47.0) [v1.48.0](https://github.com/grpc/grpc/releases/tag/v1.48.0) fixes this issue, while it's not the completed fix and will be updated more (just like https://github.com/apache/arrow/pull/14499)