### PR TITLE
Avoid namespace conflicts for protos duplicated from google.rpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ EVENTSTORE_IMAGE_TAG ?= 22.10.2-bullseye-slim
 # EVENTSTORE_IMAGE_TAG ?= 21.10.11-dev
 
 POETRY ?= poetry
+POETRY_VERSION=1.5.1
 POETRY_INSTALLER_URL ?= https://install.python-poetry.org
 PYTHONUNBUFFERED: 1
 

--- a/protos/esdbclient/protos/Grpc/code.proto
+++ b/protos/esdbclient/protos/Grpc/code.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package google.rpc;
+package esdbclient.rpc;
 
 option go_package = "google.golang.org/genproto/googleapis/rpc/code;code";
 option java_multiple_files = true;

--- a/protos/esdbclient/protos/Grpc/status.proto
+++ b/protos/esdbclient/protos/Grpc/status.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package google.rpc;
+package esdbclient.rpc;
 
 import "google/protobuf/any.proto";
 import "esdbclient/protos/Grpc/code.proto";
@@ -35,7 +35,7 @@ option objc_class_prefix = "RPC";
 // [API Design Guide](https://cloud.google.com/apis/design/errors).
 message Status {
 	// The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-	google.rpc.Code code = 1;
+	esdbclient.rpc.Code code = 1;
 
 	// A developer-facing error message, which should be in English. Any
 	// user-facing error message should be localized and sent in the

--- a/protos/esdbclient/protos/Grpc/streams.proto
+++ b/protos/esdbclient/protos/Grpc/streams.proto
@@ -232,7 +232,7 @@ message BatchAppendReq {
 message BatchAppendResp {
 	event_store.client.UUID correlation_id = 1;
 	oneof result {
-		google.rpc.Status error = 2;
+		esdbclient.rpc.Status error = 2;
 		Success success = 3;
 	}
 


### PR DESCRIPTION
The duplicated protos (`code.proto` and `status.proto`) cause this error when another package relying on these definitions is used in the same project: 

```
TypeError: Conflict register for file "google/rpc/status.proto": google.rpc.Status is already defined in file "esdbclient/protos/Grpc/status.proto". Please fix the conflict by adding package name on the proto file, or use different name for the duplication.
```

This PR fixes this by moving the duplicated definitions to their own package/namespace, thus avoiding the namespace conflict. 

Is there a good reason to have these definitions duplicated in the project?