### PR TITLE
Pull es-gencert-cli from docker.eventstore.com

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     network_mode: none
 
   cert-gen:
-    image: eventstore/es-gencert-cli:1.0.2
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     entrypoint: bash
     user: "1000:1000"
     command: >


### PR DESCRIPTION
Changed: updated root compose file to pull the `es-gencert-cli` image from `docker.eventstore.com`.