### PR TITLE
Add support for TlsCaFile in connection string for root_certificates parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,15 +379,17 @@ client will attempt to create a "secure" connection. And so, when connecting to 
 to make an "insecure" connection by using the URI query string field-value `Tls=false`.
 
 The optional `root_certificates` argument can be either a Python `str` or a Python `bytes`
-object containing PEM encoded SSL/TLS certificate(s), and is used by to authenticate the
+object containing PEM encoded SSL/TLS certificate(s), and is used to authenticate the
 server to the client. When connecting to an "insecure" service, the value of this
 argument will be ignored. When connecting to a "secure" server, it may be necessary to
-set this argument.  Typically, the value of this argument would be the public certificate
+set this argument. Typically, the value of this argument would be the public certificate
 of the certificate authority that was responsible for generating the certificate used by
 the EventStoreDB server. It is unnecessary to set this value in this case if certificate
 authority certificates are installed locally, such that the Python grpc library can pick
 them up from a default location. Alternatively, for development, you can use the server's
 certificate itself. The value of this argument is passed directly to `grpc.ssl_channel_credentials()`.
+
+An alternative way to supply the `root_certificates` argument is through the `tlsCaFile` field-value of the connection string URI query string (see below). If the `tlsCaFile` field-value is specified, the `root_certificates` argument will be ignored.
 
 The optional `private_key` and `certificate_chain` arguments are both either a Python
 `str` or a Python `bytes` object. These arguments may be used to authenticate the client
@@ -505,6 +507,7 @@ appropriate value, separated with the "=" character.
                 | ( "DiscoveryInterval", "=" , integer )
                 | ( "KeepAliveInterval", "=" , integer )
                 | ( "KeepAliveTimeout", "=" , integer ) ;
+                | ( "TlsCaFile", "=" , string ) ;
                 | ( "UserCertFile", "=" , string ) ;
                 | ( "UserKeyFile", "=" , string ) ;
 
@@ -522,6 +525,7 @@ The table below describes the query string field-values supported by this client
 | DiscoveryInterval   | integer (default: 100)                                                | How long to wait (in milliseconds) between gossip retries.                                                                                                        |
 | KeepAliveInterval   | integer (default: `None`)                                             | The value (in milliseconds) of the "grpc.keepalive_ms" gRPC channel option.                                                                                       |
 | KeepAliveTimeout    | integer (default: `None`)                                             | The value (in milliseconds) of the "grpc.keepalive_timeout_ms" gRPC channel option.                                                                               |
+| TlsCaFile           | string (default: `None`)                                              | Absolute filesystem path to file containing the CA certicate in PEM format. This will be used to verify the server's certificate.                                 |
 | UserCertFile        | string (default: `None`)                                              | Absolute filesystem path to file containing the X.509 user certificate in PEM format.                                                                             |
 | UserKeyFile         | string (default: `None`)                                              | Absolute filesystem path to file containing the X.509 user certificate's private key in PEM format.                                                               |
 

--- a/esdbclient/client.py
+++ b/esdbclient/client.py
@@ -172,17 +172,24 @@ class BaseEventStoreDBClient(ABC):
         )
         self.connection_spec = ConnectionSpec(uri)
 
+        # Load private_key from UserKeyFile if specified
         if self.connection_spec.options.UserKeyFile:
             with open(self.connection_spec.options.UserKeyFile, "r+b") as f:
                 self.private_key = f.read()
         else:
             self.private_key = None
 
+        # Load certificate_chain from UserCertFile if specified
         if self.connection_spec.options.UserCertFile:
             with open(self.connection_spec.options.UserCertFile, "r+b") as f:
                 self.certificate_chain = f.read()
         else:
             self.certificate_chain = None
+
+        # Load root_certificates from TlsCaFile if specified
+        if self.connection_spec.options.TlsCaFile:
+            with open(self.connection_spec.options.TlsCaFile, "r+b") as f:
+                self.root_certificates = f.read()
 
         self._default_deadline = self.connection_spec.options.DefaultDeadline
 

--- a/esdbclient/connection_spec.py
+++ b/esdbclient/connection_spec.py
@@ -30,6 +30,7 @@ VALID_CONNECTION_QUERY_STRING_FIELDS = [
     "DefaultDeadline",
     "KeepAliveInterval",
     "KeepAliveTimeout",
+    "TlsCaFile",
     "UserCertFile",
     "UserKeyFile",
 ]
@@ -53,6 +54,7 @@ class ConnectionOptions:
         self._set_DefaultDeadline(options)
         self._set_KeepAliveInterval(options)
         self._set_KeepAliveTimeout(options)
+        self._set_TlsCaFile(options)
         self._set_UserCertFile(options)
         self._set_UserKeyFile(options)
 
@@ -160,6 +162,13 @@ class ConnectionOptions:
         else:
             self._KeepAliveTimeout = int(_KeepAliveTimeout)
 
+    def _set_TlsCaFile(self, options: Dict[str, Any]) -> None:
+        _TlsCaFile = options.get("TlsCaFile".upper())
+        if _TlsCaFile is None:
+            self._TlsCaFile: Optional[str] = None
+        else:
+            self._TlsCaFile = str(_TlsCaFile)
+
     def _set_UserCertFile(self, options: Dict[str, Any]) -> None:
         _UserCertFile = options.get("UserCertFile".upper())
         if _UserCertFile is None:
@@ -253,6 +262,13 @@ class ConnectionOptions:
         gRPC "keep alive timeout" (in milliseconds).
         """
         return self._KeepAliveTimeout
+
+    @property
+    def TlsCaFile(self) -> Optional[str]:
+        """
+        Path to file containing root CA certificate(s) to verify server.
+        """
+        return self._TlsCaFile
 
     @property
     def UserCertFile(self) -> Optional[str]:

--- a/tests/test_asyncio_client.py
+++ b/tests/test_asyncio_client.py
@@ -2997,17 +2997,21 @@ class TestOptionalClientAuth(TimedTestCase, IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.user_key = b"some-key"
         self.user_cert = b"some-cert"
+        self.tls_ca_file = b"some-cert"
         with NamedTemporaryFile(delete=False) as f1, NamedTemporaryFile(
             delete=False
-        ) as f2:
+        ) as f2, NamedTemporaryFile(delete=False) as f3:
             f1.write(self.user_key)
             f2.write(self.user_cert)
+            f3.write(self.tls_ca_file)
             self.user_key_file = f1.name
             self.user_cert_file = f2.name
+            self.tls_ca_file = f3.name
 
     def tearDown(self) -> None:
         os.remove(self.user_key_file)
         os.remove(self.user_cert_file)
+        os.remove(self.tls_ca_file)
 
     async def test_tls_true_client_auth(self) -> None:
         secure_grpc_target = "localhost:2114"
@@ -3039,6 +3043,18 @@ class TestOptionalClientAuth(TimedTestCase, IsolatedAsyncioTestCase):
         # Should raise SSL error.
         with self.assertRaises(SSLError):
             await client.get_commit_position()
+
+        # Construct client with TlsCaFile (instead of passing root_certificates directly).
+        uri += f"&TlsCaFile={self.tls_ca_file}"
+        client_with_tls_ca = await AsyncioEventStoreDBClient(uri)
+
+        # Read the contents of TlsCaFile as bytes, since root_certificates are compared as bytes
+        with open(self.tls_ca_file, "rb") as f:
+            tls_ca_file_contents = f.read()
+
+        # TlsCaFile should override the root_certificates passed directly.
+        self.assertNotEqual(root_certificates, client_with_tls_ca.root_certificates)
+        self.assertEqual(tls_ca_file_contents, client_with_tls_ca.root_certificates)
 
 
 class TestAsyncioEventStoreDBClient(TimedTestCase, IsolatedAsyncioTestCase):

--- a/tests/test_asyncio_client.py
+++ b/tests/test_asyncio_client.py
@@ -2997,13 +2997,13 @@ class TestOptionalClientAuth(TimedTestCase, IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.user_key = b"some-key"
         self.user_cert = b"some-cert"
-        self.tls_ca_file = b"some-cert"
+        self.tls_ca = b"some-cert"
         with NamedTemporaryFile(delete=False) as f1, NamedTemporaryFile(
             delete=False
         ) as f2, NamedTemporaryFile(delete=False) as f3:
             f1.write(self.user_key)
             f2.write(self.user_cert)
-            f3.write(self.tls_ca_file)
+            f3.write(self.tls_ca)
             self.user_key_file = f1.name
             self.user_cert_file = f2.name
             self.tls_ca_file = f3.name

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6758,13 +6758,13 @@ class TestOptionalClientAuth(TimedTestCase):
     def setUp(self) -> None:
         self.user_key = b"some-key"
         self.user_cert = b"some-cert"
-        self.tls_ca_file = b"some-cert"
+        self.tls_ca = b"some-cert"
         with NamedTemporaryFile(delete=False) as f1, NamedTemporaryFile(
             delete=False
         ) as f2, NamedTemporaryFile(delete=False) as f3:
             f1.write(self.user_key)
             f2.write(self.user_cert)
-            f3.write(self.tls_ca_file)
+            f3.write(self.tls_ca)
             self.user_key_file = f1.name
             self.user_cert_file = f2.name
             self.tls_ca_file = f3.name


### PR DESCRIPTION
### Overview
This PR introduces support for passing the `TlsCaFile` parameter through the connection string, allowing it to be used as the `root_certificates` parameter for `EventStoreDBClient`. 

### Changes:
- Added `TlsCaFile` as a supported option in the connection string, similar to how `userCertFile` and `userKeyFile` are implemented.
- The `TlsCaFile` will be parsed and passed to the `root_certificates` argument in the `EventStoreDBClient`.
  
### Testing:
- Updated the connection string parser to handle `TlsCaFile`.
- Ensured that the root certificates are correctly loaded from the specified `TlsCaFile`.
- Added unit tests to validate this functionality.

**Test Result:** https://app.warp.dev/block/2GW4m0kApWnR2GKP6ifKTi

### Motivation:
The motivation behind this change is to align the Python EventStoreDB client with other EventStoreDB clients (e.g., .NET, Java, Node.js, Go, Rust), which already support the TlsCaFile feature. This enables users to pass a custom root CA certificate for secure TLS connections in the same way across all major clients.