### PR TITLE
Fix missing subscription_id in AsyncPersistentSubscription.init()

### DIFF
--- a/kurrentdbclient/persistent.py
+++ b/kurrentdbclient/persistent.py
@@ -517,6 +517,7 @@ class AsyncPersistentSubscription(
                 ):  # pragma: no cover
                     raise SubscriptionConfirmationError
                 self._subscription_id = subscription_id
+                self._read_reqs.subscription_id = subscription_id.encode()
             else:  # pragma: no cover
                 msg = f"Expected subscription confirmation, got: {first_read_resp}"
                 raise KurrentDBClientError(msg)

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -2473,6 +2473,62 @@ class TestAsyncKurrentDBClient(TimedTestCase, IsolatedAsyncioTestCase):
             pass
         self.assertTrue(cast(AsyncPersistentSubscription, s)._is_stopped)
 
+    async def test_persistent_subscription_sets_subscription_id_on_read_reqs(
+        self,
+    ) -> None:
+        """Test that AsyncPersistentSubscription.init() sets subscription_id on _read_reqs.
+
+        This is a regression test for issue #35 where ACK messages were sent with
+        an empty subscription_id field because _read_reqs.subscription_id was not
+        being set in the async version (it was only set in the sync version).
+        """
+        group_name = str(uuid4())
+        await self.client.create_subscription_to_all(group_name, from_end=True)
+
+        subscription = await self.client.read_subscription_to_all(group_name)
+        sub = cast(AsyncPersistentSubscription, subscription)
+
+        # Verify subscription_id property is set correctly
+        expected_subscription_id = f"$all::{group_name}"
+        self.assertEqual(sub.subscription_id, expected_subscription_id)
+
+        # Verify _read_reqs.subscription_id is also set (this was the bug fix)
+        self.assertEqual(
+            sub._read_reqs.subscription_id,
+            expected_subscription_id.encode(),
+        )
+
+        await subscription.stop()
+
+    async def test_persistent_subscription_to_stream_sets_subscription_id_on_read_reqs(
+        self,
+    ) -> None:
+        """Test that AsyncPersistentSubscription.init() sets subscription_id for streams.
+
+        This is a regression test for issue #35 where ACK messages were sent with
+        an empty subscription_id field.
+        """
+        group_name = str(uuid4())
+        stream_name = str(uuid4())
+        await self.client.create_subscription_to_stream(group_name, stream_name)
+
+        subscription = await self.client.read_subscription_to_stream(
+            group_name, stream_name
+        )
+        sub = cast(AsyncPersistentSubscription, subscription)
+
+        # Verify subscription_id property is set correctly
+        expected_subscription_id = f"{stream_name}::{group_name}"
+        self.assertEqual(sub.subscription_id, expected_subscription_id)
+
+        # Verify _read_reqs.subscription_id is also set (this was the bug fix)
+        self.assertEqual(
+            sub._read_reqs.subscription_id,
+            expected_subscription_id.encode(),
+        )
+
+        await subscription.stop()
+
     # async def test_subscribe_to_all_raises_discovery_failed(self) -> None:
     #     await self.client._connection.close()
     #     # Reconstruct connection with wrong port (to inspire ServiceUnavailble).


### PR DESCRIPTION
## Summary

This fixes issue #35 where ACK messages were sent with an empty `subscription_id` field, which EventStoreDB silently ignores. The result was that events were being redelivered after `message_timeout` expires, despite being successfully ACKed by the client.

## The Problem

The synchronous `PersistentSubscription.__init__()` correctly sets:

```python
self._read_reqs.subscription_id = subscription_id.encode()
```

But the async version `AsyncPersistentSubscription.init()` was **missing this line**.

## The Fix

Added the missing line to `AsyncPersistentSubscription.init()`:

```python
self._subscription_id = subscription_id
self._read_reqs.subscription_id = subscription_id.encode()  # <-- Added this line
```

## Tests Added

Added two regression tests to `tests/test_client_async.py`:

- **`test_persistent_subscription_sets_subscription_id_on_read_reqs`** - Verifies that `_read_reqs.subscription_id` is correctly set for `$all` subscriptions
- **`test_persistent_subscription_to_stream_sets_subscription_id_on_read_reqs`** - Verifies that `_read_reqs.subscription_id` is correctly set for stream subscriptions

Both tests verify:

1. The `subscription_id` property is set correctly
2. The `_read_reqs.subscription_id` is set to the encoded subscription ID (this was the bug)

## Symptoms Fixed

1. Events being processed successfully but ACKs silently ignored by EventStoreDB
2. Subscription checkpoint never advancing
3. Events being redelivered every `message_timeout` seconds (default: 30s)
4. `inFlightMessages` in subscription info staying constant

Fixes #35
